### PR TITLE
🐛 개발 환경을 판정하는 코드 오류 수정

### DIFF
--- a/src/service/awsSignedCookies.js
+++ b/src/service/awsSignedCookies.js
@@ -3,13 +3,14 @@ import { getSignedCookies } from "@aws-sdk/cloudfront-signer";
 export function attachMediaCookies(res) {
     // JWT 검증 통과한 사용자만 여기까지 오게
 
-    const isDev = process.env.NODE_ENV !== "production"; // 또는 process.env.IS_DEV === "true"
+    const isDev = process.env.isDev === "true";
     if (isDev) {
         return;
     }
 
     const seconds = 60 * 60 * 24; // JWT랑 동일하게
-    const url = process.env.AWS_S3_URL + "/*";
+    const cfBase = (process.env.AWS_S3_URL || "").replace(/\/$/, "");
+    const url = `${cfBase}/*`;
     const privateKey = (process.env.AWS_CLOUDFRONT_KEY_PEM || "").replace(/\\n/g, "\n"); //전처리
 
     const cookies = getSignedCookies({


### PR DESCRIPTION
const isProd = process.env.NODE_ENV === "production";
if (!isProd) return; // 개발이면 스킵

코드에 오류가 있어 항상 true가 나오는 문제가 있었음