### PR TITLE
✨홈페이지 feed 관련 API 개발 및 캐싱 전략 구현

### DIFF
--- a/src/config/serverConfig.js
+++ b/src/config/serverConfig.js
@@ -70,3 +70,6 @@ export const emojiSpecDefinition = {
 };
 
 export const DAYS_BEFORE_DELETION = 7; //게시글 삭제 처리후 몇일후 지울건지
+
+export const CACHE_TTL_LATEST = 60; // 최신글을 캐싱하는데 필요한 최소 TTL
+export const CACHE_TTL_TOP = 180; //이번달 최고 인기글 캐싱하는데 필요한 최소 TTL

--- a/src/controllers/boardController.js
+++ b/src/controllers/boardController.js
@@ -2,6 +2,7 @@ import {
     createBoardService,
     deleteBoardService,
     editBoardService,
+    getFeedService,
     toggleLikeService,
 } from "../service/boardService.js";
 import { getPrisma } from "../service/prismaService.js";
@@ -227,4 +228,13 @@ export const toggleLike = async (req, res) => {
         `${printUserInfo(req)} / ${req.params.id}번 게시글 추천 토글. 상태 :${result.like ? "👍" : "👎"}`
     );
     return res.status(result.code).json({ message: result.message, like: result.like });
+};
+
+export const getFeed = async (req, res) => {
+    try {
+        const result = await getFeedService(req);
+        return res.status(200).json(result);
+    } catch (err) {
+        logger().warn("피드 출력중 오류 발생", err);
+    }
 };

--- a/src/routes/boardRoute.js
+++ b/src/routes/boardRoute.js
@@ -5,6 +5,7 @@ import {
     editBoard,
     getBoardDetail,
     getBoardList,
+    getFeed,
     toggleLike,
 } from "../controllers/boardController.js";
 
@@ -17,5 +18,6 @@ boardRouter.get("/detail", getBoardDetail);
 boardRouter.patch("/:id", editBoard);
 boardRouter.delete("/:id", deleteBoard);
 boardRouter.post("/:id/like", toggleLike);
+boardRouter.get("/feed", getFeed);
 
 export default boardRouter;

--- a/src/service/redisService.js
+++ b/src/service/redisService.js
@@ -35,3 +35,77 @@ export function getRedisClient() {
     }
     return redisClient;
 }
+
+//Feed 관련 캐싱 메서드
+
+export function createFeedCacheUtils() {
+    function monthKeyKST(date = new Date()) {
+        const kst = new Date(date.toLocaleString("en-US", { timeZone: "Asia/Seoul" }));
+        const y = kst.getFullYear();
+        const m = String(kst.getMonth() + 1).padStart(2, "0");
+        return `${y}${m}`;
+    }
+
+    function monthRangeKST(yyyymm) {
+        const y = Number(yyyymm.slice(0, 4));
+        const m = Number(yyyymm.slice(4, 6)) - 1;
+
+        const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+        // KST 00:00을 UTC instant로 환산
+        const start = new Date(Date.UTC(y, m, 1, 0, 0, 0) - KST_OFFSET_MS);
+        const end = new Date(Date.UTC(y, m + 1, 1, 0, 0, 0) - KST_OFFSET_MS);
+
+        return { start, end };
+    }
+
+    async function redisGetJson(redis, key) {
+        const raw = await redis.get(key);
+        if (!raw) {
+            return null;
+        }
+        try {
+            return JSON.parse(raw);
+        } catch {
+            return null;
+        }
+    }
+
+    async function redisSetJson(redis, key, value, ttlSec) {
+        const raw = JSON.stringify(value);
+        return redis.set(key, raw, { EX: ttlSec });
+    }
+
+    async function getVersion(redis, verKey) {
+        const v = await redis.get(verKey);
+        return v ? Number(v) : 1;
+    }
+
+    async function withBuildLock(redis, lockKey, workFn) {
+        const ok = await redis.set(lockKey, "1", { NX: true, EX: 3 });
+        if (ok) {
+            try {
+                return await workFn();
+            } finally {
+                // EX가 있어서 굳이 DEL 안 해도 되지만, 빨리 풀면 좋음
+                try {
+                    await redis.del(lockKey);
+                } catch {}
+            }
+        }
+
+        // 락 못잡았으면 잠깐 기다렸다가(짧게) 캐시 재시도
+        await new Promise(r => setTimeout(r, 120));
+        return null;
+    }
+
+    // 밖에서 쓸 것만 반환
+    return {
+        monthKeyKST,
+        monthRangeKST,
+        redisGetJson,
+        redisSetJson,
+        getVersion,
+        withBuildLock,
+    };
+}


### PR DESCRIPTION
## PR: 홈 피드 API + Redis 캐싱(버전 범프)

- Feed API 추가: `GET /api/feed` → `{ latest, top, yyyymm }`
  - `latest`: 최신글 5개
  - `top`: KST 기준 이번달 추천수 TOP 5 (`recommend_cnt >= 1`)

### 캐싱 전략
- Redis **고정키 + 버전 범프(INCR)** 방식
  - 최신글
    - `feed:latest:ver` → `feed:latest:v{ver}`
  - 이번달 TOP
    - `feed:top:{YYYYMM}:ver` → `feed:top:{YYYYMM}:v{ver}` (`YYYYMM`은 KST 기준)

- 무효화(invalidate)는 인자 없는 메서드 호출로 처리
  - 글 생성 시: `invalidateLatestFeed()` → `INCR feed:latest:ver`
  - 추천/취소 시: `invalidateTopMonthFeed()` → `INCR feed:top:{YYYYMM}:ver`

- 캐시 생성 시 **락 + TTL** 적용
  - 동시 캐시 미스 시 DB 폭주 방지(락)
  - 추천 이벤트가 잦아도 DB 폭증 방지(TTL: `CACHE_TTL_LATEST`, `CACHE_TTL_TOP`)

### 시간 처리
- DB 저장은 UTC 유지
- “이번달” 계산은 KST 기준으로 하고, 쿼리 범위는 UTC 저장값에 맞게 구성
- 출력(표시)은 프론트에서 KST 포맷 처리
