### PR TITLE
🐛 글 삭제시 캐싱 초기화가 되지 않는 문제 해결

### DIFF
--- a/src/service/boardService.js
+++ b/src/service/boardService.js
@@ -209,6 +209,10 @@ export async function deleteBoardService(user, board_id) {
             }),
         ]);
 
+        //게시글 삭제시 , 최신글 일 가능성 & TOP 5일 가능성을 고려해서 전부 캐싱 초기화
+        await invalidateLatestFeed();
+        await invalidateTopMonthFeed();
+
         return {
             ok: true,
             code: 200,


### PR DESCRIPTION
# 📌 Pull Request

## 📄 요약

글 삭제 로직에 캐싱 초기화가 되어 있지 않아서 사용자가 빈 게시글을 보는 경우가 많았음

추가적으로 캐싱 문제가 아니더라도, 사용자가 빈 게시글을 보는 경우가 생길 수 있어서 빈 게시글인 경우 프론트에서 뒤로 보내주는 로직도 추가

rel : https://github.com/4cozm/CAT4U_WEB_FRONTEND/issues/103

---

## 🧪 변경 사항 확인용 체크리스트

- [X] **기능 테스트 완료**: 변경된 기능이 정상 동작하는지 확인함
- [X] **테스트 코드 작성 or 수정함** 
- [X] **테스트용 console.log / 주석 제거함**
- [X] **실제 비즈니스 로직 외의 임시 코드가 남아있지 않음**
- [X] **Wiki / README 등 문서 업데이트 완료**

---

