### PR TITLE
fix: MySQL 재시작 후 DB 풀 타임아웃 해결 (caching_sha2_password RSA 키)

### DIFF
--- a/src/config/mysqlOptions.js
+++ b/src/config/mysqlOptions.js
@@ -5,4 +5,8 @@ export const getMysqlOptions = () => ({
     password: process.env.MYSQL_PASSWORD,
     database: "default",
     connectionLimit: 10,
+    // MySQL 8 caching_sha2_password: 비TLS 연결에서 첫 인증 시 서버 RSA 공개키 교환이 필요.
+    // MySQL 재시작으로 인증 캐시가 비워지면 매 연결이 키 교환을 다시 타는데, 이 옵션이 없으면
+    // "RSA public key is not available" → 인증 실패 → pool timeout 으로 이어진다. (localhost 한정 안전)
+    allowPublicKeyRetrieval: true,
 });

--- a/src/service/prismaService.js
+++ b/src/service/prismaService.js
@@ -39,6 +39,9 @@ export async function connectWithRetry(shutdown = false, retries = 3, delay = 20
                 spinner.succeed("DB 연결 성공");
                 return prisma;
             } catch (e) {
+                // 전체 에러/cause 체인을 기록. spinner 문구는 e.message만 보여줘서
+                // 드라이버 어댑터의 근본 원인(예: 인증 실패)이 가려지는 걸 방지한다.
+                logger().error(e);
                 spinner.warn(`DB 연결 실패 (${i + 1}/${retries}) - ${e.message}`);
                 await new Promise(r => setTimeout(r, delay));
                 spinner.start();


### PR DESCRIPTION
## 문제

`npm run start`로 서버를 켜면 DB 연결 단계에서 멈추다가 **타임아웃**이 나며 죽었다. 그런데:

- `docker exec`로 컨테이너 안에서 `mysql` 수동 접속은 **정상**
- 환경변수(IP·비밀번호 등) 전부 정상, `nc -vz 127.0.0.1 3306`도 성공 (TCP는 멀쩡)
- **비용 절감용으로 AWS 인스턴스를 suspend 했다가 켠 뒤부터** 발생. 재부팅해도 동일
- 예전에도 간헐적으로 있었으나 원인 미상으로 넘어갔던 이슈

## 진짜 원인

표면상 "타임아웃"이지만 에러 `cause` 체인 맨 안쪽이 진짜 원인이었다:

```
RSA public key is not available client side.
... allow public key retrieval with option `allowPublicKeyRetrieval`
```

MySQL 8 기본 인증 방식 `caching_sha2_password`는, non-TLS 연결의 **첫 인증 때 서버 RSA 공개키를 받아** 비밀번호를 암호화해 보낸다. mariadb 드라이버는 이 공개키 수신이 기본 비활성(`allowPublicKeyRetrieval=false`)이라 인증에 실패 → 커넥션 풀이 안 채워짐 → `pool timeout`.

### 왜 "suspend 후"부터 깨졌나

`caching_sha2_password`는 한 번 인증 성공하면 결과를 **메모리에 캐시**해 이후 연결은 공개키 교환을 건너뛴다. 인스턴스 suspend로 MySQL 컨테이너가 죽으면 **이 캐시가 통째로 비워지고**, 재시작 직후 첫 연결이 다시 공개키 경로를 타면서 위 실패가 드러난다. (수동 `mysql` 접속은 유닉스 소켓이라 RSA 교환 자체가 생략돼 항상 됐던 것.)

## 변경 사항

- `mysqlOptions.js`: `allowPublicKeyRetrieval: true` 추가 — localhost 컨테이너 접속이라 MITM 여지가 없어 안전
- `prismaService.js`: 연결 실패 시 `logger().error(e)`로 전체 `cause` 체인 기록 — 기존엔 `e.message`만 출력돼 이번 같은 근본 원인이 가려졌음

## 검증

EC2에서 인라인 Prisma 연결 스크립트로 `$connect`가 즉시 끝나고 `SELECT 1` 정상 반환 확인.

